### PR TITLE
Removed getId method from SequenceIdentifierTrait that should no longer be used

### DIFF
--- a/src/Application/ActionFactory.php
+++ b/src/Application/ActionFactory.php
@@ -21,7 +21,11 @@ abstract class ActionFactory implements ActionFactoryInterface
         $this->container = $container;
     }
 
-    public function getLogger(): LoggerInterface
+	/**
+	 * @throws \Psr\Container\ContainerExceptionInterface
+	 * @throws \Psr\Container\NotFoundExceptionInterface
+	 */
+	public function getLogger(): LoggerInterface
     {
         return $this->container->get(LoggerInterface::class);
     }

--- a/src/Application/Response/StatusCode.php
+++ b/src/Application/Response/StatusCode.php
@@ -54,7 +54,7 @@ class StatusCode
 	const REDIRECTION_TEMPORARY_REDIRECT = 307;
 
 	/**
-	 * The request, and all future requests should be repeated using another URI
+	 * The request and all future requests should be repeated using another URI
 	 * (experimental)
 	 */
 	const REDIRECTION_PERMANENT_REDIRECT = 308;

--- a/src/Application/Serializer.php
+++ b/src/Application/Serializer.php
@@ -32,7 +32,7 @@ class Serializer implements SerializerInterface, SerializerAwareInterface
     }
 
     /** @noinspection PhpParameterNameChangedDuringInheritanceInspection */
-    public function deserialize($data, string $type,): object
+    public function deserialize($data, string $type): object
     {
         return $this->serializer->deserialize($data, $type, static::FORMAT);
     }

--- a/src/Domain/SequenceIdentifierTrait.php
+++ b/src/Domain/SequenceIdentifierTrait.php
@@ -21,9 +21,4 @@ trait SequenceIdentifierTrait
 	 */
 	#[Groups([SerializerInterface::LIST_GROUP])]
 	protected int $id;
-
-	public function getId(): IntegerIdentifier
-	{
-		return IntegerIdentifier::fromInt($this->id);
-	}
 }

--- a/src/Infrastructure/Persistence/DoctrineRepository.php
+++ b/src/Infrastructure/Persistence/DoctrineRepository.php
@@ -15,7 +15,7 @@ abstract class DoctrineRepository
 	}
 
 	/**
-	 * Find Entity by it's primary key, return null if entity does not exist
+	 * Find Entity by its primary key, return null if entity does not exist
 	 *
 	 * @throws Exceptions\ConnectionException
 	 * @throws PersistenceException

--- a/src/Infrastructure/Persistence/QueryLogger.php
+++ b/src/Infrastructure/Persistence/QueryLogger.php
@@ -10,10 +10,7 @@ class QueryLogger implements SQLLogger
 {
 	private ?int $start;
 
-	/**
-	 * @var string|null
-	 */
-	private $sql;
+	private ?string $sql;
 
 	private ?array $params = null;
 


### PR DESCRIPTION
Removed getId method from SequenceIdentifierTrait that should no longer be used, comment changes